### PR TITLE
Update jsDelivr link

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ If you known some idea for mobile browser, you could send pull request.
 ## Installation
 Using CDN: 
 ```
-<script src="//cdn.jsdelivr.net/check-browsers/1.0.4/check-browsers.min.js"></script>
+<script src="//cdn.jsdelivr.net/npm/check-browsers@1.0.8/dist/check-browsers.min.js"></script>
 ```
 Using npm:
 ```


### PR DESCRIPTION
[jsDelivr switched to a fully automated system](https://www.jsdelivr.com/features), that can serve files from npm and GitHub. This means all future releases will be available automatically, but will use a new link structure.

I updated the link now so you don't forget to do it when you release a new version.

You can find links for all files at https://www.jsdelivr.com/package/npm/check-browsers.

Feel free to ping me if you have any questions regarding this change.